### PR TITLE
Fix: Let officer die completely on suicide

### DIFF
--- a/ExtraRoles/PerformKillPatch.cs
+++ b/ExtraRoles/PerformKillPatch.cs
@@ -277,7 +277,6 @@ namespace ExtraRolesMod
         [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.MurderPlayer))]
         public static class MurderPlayerPatch
         {
-            public static bool orgDead = false;
 
             public static bool Prefix(PlayerControl __instance, PlayerControl CAKODNGLPDF)
             {
@@ -286,9 +285,6 @@ namespace ExtraRolesMod
                 {
                     //if so, set them to impostor for one frame so they aren't banned for anti-cheat
                     __instance.Data.IsImpostor = true;
-                    //code that allows Impostor and Officer to trade in very specific circumstances
-                    orgDead = __instance.Data.IsDead;
-                    __instance.Data.IsDead = false;
                 }
                 return true;
             }
@@ -304,7 +300,6 @@ namespace ExtraRolesMod
                 if (__instance.isPlayerRole("Officer"))
                 {
                     __instance.Data.IsImpostor = false;
-                    __instance.Data.IsDead = orgDead;
                 }
                 if (__instance.PlayerId == CAKODNGLPDF.PlayerId)
                 {


### PR DESCRIPTION
I'm not really sure what you mean by "code that allows Impostor and Officer to trade in very specific circumstances". But as it is now, the officer will not correctly die by suicide. He will leave a body of himself, but continue living, visible by anybody and can interact normally (including dying multiple times). He CAN however walk through walls and see everything like a ghost.

The bug was introduced in the refactoring in commit https://github.com/NotHunter101/ExtraRolesAmongUs/commit/09c85e4bf7d9e310807968ebc73db6e3f6681e6f and I basically reverted the "orgDead" member variable.