### PR TITLE
#65 Give players a visual indicator that the shield was broken

### DIFF
--- a/ExtraRoles/ExtraRoles.cs
+++ b/ExtraRoles/ExtraRoles.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Reactor.Unstrip;
 using static ExtraRolesMod.ExtraRoles;
+using ExtraRoles.Medic;
 
 namespace ExtraRolesMod
 {
@@ -77,7 +78,7 @@ namespace ExtraRolesMod
         /// </summary>
         public static bool isPlayerImmortal(this PlayerControl plr)
         {
-            return plr.getModdedControl() != null && plr.getModdedControl().Immortal;
+            return plr.getModdedControl() != null && plr.getModdedControl().Immortal != ShieldState.None;
         }
 
         public static ModPlayerControl getModdedControl(this PlayerControl plr)
@@ -106,12 +107,12 @@ namespace ExtraRolesMod
 
             public ModPlayerControl getImmortalPlayer()
             {
-                return Main.Logic.AllModPlayerControl.Find(x => x.Immortal);
+                return Main.Logic.AllModPlayerControl.Find(x => x.Immortal != ShieldState.None);
             }
 
             public bool anyPlayerImmortal()
             {
-                return Main.Logic.AllModPlayerControl.FindAll(x => x.Immortal).Count > 0;
+                return Main.Logic.AllModPlayerControl.FindAll(x => x.Immortal != ShieldState.None).Count > 0;
             }
 
             public void clearJokerTasks()
@@ -156,7 +157,12 @@ namespace ExtraRolesMod
         public static void BreakShield(bool flag)
         {
             if (PlayerControl.LocalPlayer.isPlayerImmortal())
+            {
                 SoundManager.Instance.PlaySound(Main.Assets.breakClip, false, 100f);
+                PlayerControl.LocalPlayer.myRend.material.SetColor("_VisorColor", Palette.VisorColor);
+                PlayerControl.LocalPlayer.myRend.material.SetFloat("_Outline", 0f);
+                PlayerControl.LocalPlayer.getModdedControl().Immortal = ShieldState.Broken;
+            }
 
             if (!flag)
                 return;
@@ -167,7 +173,7 @@ namespace ExtraRolesMod
             var immortal = Main.Logic.getImmortalPlayer();
             immortal.PlayerControl.myRend.material.SetColor("_VisorColor", Palette.VisorColor);
             immortal.PlayerControl.myRend.material.SetFloat("_Outline", 0f);
-            immortal.Immortal = false;
+            immortal.Immortal = ShieldState.None;
         }
 
         public static GameObject rend;
@@ -198,7 +204,7 @@ namespace ExtraRolesMod
             public string Role { get; set; }
             public DateTime? LastAbilityTime { get; set; }
             public bool UsedAbility { get; set; }
-            public bool Immortal { get; set; }
+            public ShieldState Immortal { get; set; } = ShieldState.None;
         }
 
         public class ModdedConfig

--- a/ExtraRoles/Medic/ShieldState.cs
+++ b/ExtraRoles/Medic/ShieldState.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExtraRoles.Medic
+{
+    public enum ShieldState
+    {
+        None = 0,
+        Intact = 1,
+        Broken = 2
+    }
+}

--- a/ExtraRoles/PerformKillPatch.cs
+++ b/ExtraRoles/PerformKillPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using ExtraRoles.Medic;
+using HarmonyLib;
 using Hazel;
 using System;
 using UnityEngine;
@@ -96,7 +97,7 @@ namespace ExtraRolesMod
                 {
                     writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
                         (byte) CustomRPC.SetProtected, Hazel.SendOption.None, -1);
-                    target.getModdedControl().Immortal = true;
+                    target.getModdedControl().Immortal = ShieldState.Intact;
                     PlayerControl.LocalPlayer.getModdedControl().UsedAbility = true;
                     writer.Write(target.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);

--- a/ExtraRoles/RPC.cs
+++ b/ExtraRoles/RPC.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using Hazel;
 using System.Linq;
 using static ExtraRolesMod.ExtraRoles;
+using ExtraRoles.Medic;
 
 namespace ExtraRolesMod
 {
@@ -99,7 +100,7 @@ namespace ExtraRolesMod
                         Main.Logic.AllModPlayerControl.Add(new ModPlayerControl
                         {
                             PlayerControl = plr, Role = "Impostor", UsedAbility = false, LastAbilityTime = null,
-                            Immortal = false
+                            Immortal = ShieldState.None
                         });
                     crewmates.RemoveAll(x => x.Data.IsImpostor);
                     foreach (var plr in crewmates)
@@ -112,7 +113,7 @@ namespace ExtraRolesMod
                     var protectedId = ALMCIJKELCP.ReadByte();
                     foreach (var player in PlayerControl.AllPlayerControls)
                         if (player.PlayerId == protectedId)
-                            player.getModdedControl().Immortal = true;
+                            player.getModdedControl().Immortal = ShieldState.Intact;
                     break;
                 case (byte) CustomRPC.SetOfficer:
                     setRole("Officer");

--- a/ExtraRoles/SetInfectedPatch.cs
+++ b/ExtraRoles/SetInfectedPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using ExtraRoles.Medic;
+using HarmonyLib;
 using Hazel;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,7 +25,7 @@ namespace ExtraRolesMod
                 Main.Logic.AllModPlayerControl.Add(new ModPlayerControl
                 {
                     PlayerControl = plr, Role = "Impostor", UsedAbility = false, LastAbilityTime = null,
-                    Immortal = false
+                    Immortal = ShieldState.None
                 });
             crewmates.RemoveAll(x => x.Data.IsImpostor);
             foreach (var plr in crewmates)

--- a/ExtraRoles/UpdatePatch.cs
+++ b/ExtraRoles/UpdatePatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using ExtraRoles.Medic;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -192,22 +193,18 @@ namespace ExtraRolesMod
                 var shieldedPlayer = Main.Logic.getImmortalPlayer().PlayerControl;
                 if (showShielded == (int) ShieldOptions.Everyone)
                 {
-                    shieldedPlayer.myRend.material.SetColor("_VisorColor", Main.Palette.protectedColor);
-                    shieldedPlayer.myRend.material.SetFloat("_Outline", 1f);
-                    shieldedPlayer.myRend.material.SetColor("_OutlineColor", Main.Palette.protectedColor);
+                    GiveShieldedPlayerShield(shieldedPlayer);
                 }
                 else if (PlayerControl.LocalPlayer.isPlayerImmortal() && (showShielded == (int) ShieldOptions.Self || showShielded == (int) ShieldOptions.SelfAndMedic))
                 {
-                    shieldedPlayer.myRend.material.SetColor("_VisorColor", Main.Palette.protectedColor);
-                    shieldedPlayer.myRend.material.SetFloat("_Outline", 1f);
-                    shieldedPlayer.myRend.material.SetColor("_OutlineColor", Main.Palette.protectedColor);
+                   
+                    GiveShieldedPlayerShield(shieldedPlayer);
+
                 }
                 else if (PlayerControl.LocalPlayer.isPlayerRole("Medic") &&
                          (showShielded == (int) ShieldOptions.Medic || showShielded == (int) ShieldOptions.SelfAndMedic))
                 {
-                    shieldedPlayer.myRend.material.SetColor("_VisorColor", Main.Palette.protectedColor);
-                    shieldedPlayer.myRend.material.SetFloat("_Outline", 1f);
-                    shieldedPlayer.myRend.material.SetColor("_OutlineColor", Main.Palette.protectedColor);
+                    GiveShieldedPlayerShield(shieldedPlayer);
                 }
             }
 
@@ -260,6 +257,22 @@ namespace ExtraRolesMod
                     KillButton.SetTarget(null);
                     CurrentTarget = null;
                 }
+            }
+        }
+
+        private static void GiveShieldedPlayerShield(PlayerControl shieldedPlayer)
+        {
+            if (shieldedPlayer.getModdedControl().Immortal == ShieldState.Broken)
+            {
+                shieldedPlayer.myRend.material.SetColor("_VisorColor", Color.white);
+                shieldedPlayer.myRend.material.SetFloat("_Outline", 1f);
+                shieldedPlayer.myRend.material.SetColor("_OutlineColor", Color.white);
+            }
+            else
+            {
+                shieldedPlayer.myRend.material.SetColor("_VisorColor", Main.Palette.protectedColor);
+                shieldedPlayer.myRend.material.SetFloat("_Outline", 1f);
+                shieldedPlayer.myRend.material.SetColor("_OutlineColor", Main.Palette.protectedColor);
             }
         }
     }


### PR DESCRIPTION
This changes the shield to not only play a break sound for the local player but also recolor the shield into a white outline indicating that the shield was broken. Once the shield was broken the shield permanently stays in the broken state until the medic dies or the game ends.